### PR TITLE
Add SAML2 identity provider support

### DIFF
--- a/private/sp_conf.py.example
+++ b/private/sp_conf.py.example
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+## SP CONFIGURATION ##
+from saml2 import BINDING_HTTP_POST, BINDING_HTTP_REDIRECT
+import os.path
+import requests
+import tempfile
+
+#
+# This is tested with keycloak IdP, with email nameid format
+# Make SP metadata with make_metadata private/sp_conf.py > private/sp.xml
+#
+# Make sure the entity ID matches. Use pysaml2 > 6.4.
+#
+# Change appconfig.ini to contain saml2_auth = true in the [auth] section
+#
+
+idp = 'https://idp.tld/url/to/metadata'
+rv = requests.get(idp)
+tmp = tempfile.NamedTemporaryFile()
+f = open(tmp.name, 'w')
+f.write(rv.text)
+f.close()
+
+BASEDIR = os.path.abspath(os.path.dirname(__file__))
+
+def full_path(local_file):
+    return os.path.join(BASEDIR, local_file)
+
+
+CONFIG = {
+    'entityid': 'https://my.openstudio.tld/saml_metadata',
+    'service': {
+        'sp' : {
+            'name': 'openstudio',
+            'endpoints': {
+                'assertion_consumer_service': [
+                    ('https://my.openstudio.tld/user/login', BINDING_HTTP_REDIRECT),
+                    ('https://my.openstudio.tld/user/login', BINDING_HTTP_POST),
+                ],
+                "single_logout_service": [
+                    ("https://my.openstudio.tld/user/logout", BINDING_HTTP_REDIRECT),
+                ],
+            },
+            'authn_requests_signed': True,
+        },
+    },
+    'key_file': full_path('pki/mykey.pem'),
+    'cert_file': full_path('pki/mycert.pem'),
+    # where the remote metadata is stored
+    'metadata': {
+         'local': [tmp.name],
+    },
+}


### PR DESCRIPTION
Hi,

I've added SAML2 identity provider support to openstudio, to integrate openstudio with other applications, such as a video library or online video conference platform.

To get global logout to work correctly, it requires a small change in gluon as well:
in saml_handler change client = Saml2Client... etc to this:

```
    from saml2.cache import Cache
    session.saml2_cache = Cache()
    client = Saml2Client(config_file=config_filename, identity_cache=session.saml2_cache)
```
I've tested this with keycloak, which handles user registration, email confirmation, brute force protection and password resets. OpenStudio actually has to do less this way.

When using SAML2 authentication, accepting the Terms and Conditions and Privacy Policy is not currently possible within OpenStudio. OSSAULA is not used because it relies on email being in a form.vars. I believe the rest works well.

We're planning on doing terms and conditions in Keycloak as well. 

Our setup is live at https://my.yogahour.eu/ feel free to register and check the login workflow.

Hope this is generalized enough to merge. :-)

Kind regards,
Wilco Baan Hofman 
https://yogahour.nl